### PR TITLE
capture MSVC errors

### DIFF
--- a/src/gcc_matcher.jsontemplate
+++ b/src/gcc_matcher.jsontemplate
@@ -10,6 +10,14 @@
                     "column": 3,
                     "severity": 4,
                     "message": 5
+                },
+                {
+                    "regexp": "^(?:${{ BASE }}\\\\?)?(.*?)\\((\\d+)(?:,(\\d+))?\\):\\s+(?:fatal\\s+)?(warning|error)\\s+(.*(?=\\s+\\[)|.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
                 }
             ]
         }


### PR DESCRIPTION
could be a different fork msvc-problem-matcher rather than gcc-problem-matcher

see also https://github.com/microsoft/vscode-cmake-tools/issues/4262